### PR TITLE
quick edit to sync.get callback

### DIFF
--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ var settings = {
 chrome.storage.sync.get(settings, function(result) {
   if(result.domain) settings.domain = result.domain;
   if(result.ip) settings.ip = result.ip;
-  if(result.enabled) settings.enabled = result.enabled;
+  if(result.hasOwnProperty('enabled')) settings.enabled = result.enabled;
   chrome.browserAction.setIcon({path: (settings.enabled ? 'enabled' : 'disabled') + '.png'});
 });
 


### PR DESCRIPTION
the checking in the callback didn't distinguish between a missing
result.enabled field and the false value.  This meant that it setting
enabled to default on had no effect.

/doesn't make a difference in the current configuration, but introduced
a bug in a version I'm working on.
